### PR TITLE
SYS-1642: Harvest legacy digital library

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -160,3 +160,6 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+# Text files
+*.txt

--- a/README.md
+++ b/README.md
@@ -59,6 +59,13 @@ python centralsearch.py copy \
 
 Ignore security warnings in the local environment.
 
+#### List fields in Solr index
+Lists all fields in all records in a Solr index, along with number of occurrences of each field.
+Generally takes 5-15 minutes, depending on number of records.
+```
+python centralsearch.py get_solr_fields --source-url URL
+```
+
 #### Review / explore data
 
 Elasticsearch and Kibana provide the same data, but Kibana is friendlier to use via its console.

--- a/centralsearch.py
+++ b/centralsearch.py
@@ -10,6 +10,7 @@ from retry.api import retry_call
 import rich.progress
 from pysolr import Solr  # type: ignore
 from elasticsearch import Elasticsearch
+from pprint import pprint
 
 
 @click.group()
@@ -18,7 +19,7 @@ def centralsearch():
 
 
 @click.option("--max-records", default=float("inf"))
-@click.option("--source-url", required=True)
+@click.option("--source-url", required=True, help="Solr URL")
 @click.option(
     "--elastic-url",
     required=True,
@@ -28,7 +29,7 @@ def centralsearch():
 @click.option(
     "--elastic-api-key",
     default=None,
-    help="API key for Elasticsearch. Untested, I've been using username and password in --elastic-url.",
+    help="API key for Elasticsearch",
 )
 @click.option("--destination-index-name", required=True)
 @click.option("--profile", required=False)
@@ -46,7 +47,7 @@ def copy(
     profile_module = import_module(profile) if profile else None
     get_id = getattr(profile_module, "get_id", lambda x: x["id"])
     map_record = getattr(profile_module, "map_record", lambda x: x)
-    source_query = getattr(profile_module, "SOURCE_QUERY", "*:*")   
+    source_query = getattr(profile_module, "SOURCE_QUERY", "*:*")
 
     # TODO: click has a built-in progress bar; and I think pysolr can handle
     # chunking if we just iterate over a Results object
@@ -90,6 +91,37 @@ def copy(
                 progress.update(task, total=n_hits, completed=start + index)
 
             start += chunk_size
+
+
+@click.option("--source-url", required=True, help="Solr URL")
+@centralsearch.command("get_solr_fields")
+def get_solr_fields(source_url: str) -> None:
+    """List all fields in all records of a Solr index,
+    along with the number of times they occur."""
+    with rich.progress.Progress() as progress:
+        task = progress.add_task("Getting fields...", total=None)
+        source_solr = Solr(source_url, timeout=10, always_commit=True)
+        source_query = "*:*"
+        n_hits = float("inf")
+        max_records = float("inf")
+        start = 0
+        chunk_size = 250
+        all_keys = {}
+        while start < n_hits and start < max_records:
+            chunk = source_solr.search(
+                source_query, defType="lucene", start=start, rows=chunk_size
+            )
+            n_hits = chunk.hits
+            for doc in chunk.docs:
+                for key in doc.keys():
+                    if key in all_keys.keys():
+                        all_keys[key] = all_keys[key] + 1
+                    else:
+                        all_keys[key] = 1
+            progress.update(task, total=n_hits, completed=start + chunk_size)
+            start += chunk_size
+
+        pprint(dict(sorted(all_keys.items())), width=132)
 
 
 if __name__ == "__main__":

--- a/config/dl_legacy.py
+++ b/config/dl_legacy.py
@@ -1,0 +1,34 @@
+SOURCE_QUERY = "*:*"
+
+
+def get_id(record: dict) -> str:
+    return record.get("PID")
+
+
+def map_record(record: dict) -> dict:
+    # Still quite TBD....
+    # Remove Solr fields we don't want
+    # RELS_EXT*
+    # _version_
+    # fedora_*
+    # All fgs_* except fgs_label_s
+    # All mods_* except mods_titleInfo_title_s and mods_xml
+    # timestamp
+
+    # Easiest just to keep what we do want, for now
+    fields_to_keep = [
+        "PID",
+        "fgs_label_s",
+        "mods_titleInfo_title_s",
+        "mods_title_ms",
+        "mods_xml",
+    ]
+    record_keep = {}
+    for fld in fields_to_keep:
+        if fld in record:
+            record_keep[fld] = record[fld]
+
+    # Also keep all Dublin Core fields (dc.*)
+    record_keep.update({k: v for k, v in record.items() if k.startswith("dc.")})
+
+    return record_keep

--- a/config/samvera.py
+++ b/config/samvera.py
@@ -2,7 +2,6 @@ from datetime import datetime
 import re
 
 SOURCE_QUERY = "ark_ssi:*"
-HYRAX_SUFFIX = re.compile(r"_(te|s|b|dt)s?i?m?$")
 
 
 def get_id(record: dict) -> str:
@@ -11,6 +10,7 @@ def get_id(record: dict) -> str:
 
 def map_record(record: dict) -> dict:
     """Strip hyrax suffixes from field names."""
+    HYRAX_SUFFIX = re.compile(r"_(te|s|b|dt)s?i?m?$")
 
     if record.get("date_dtsim"):
         record["date_dtsim"] = [

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,3 +3,5 @@ version: "3.6"
 services:
   python:
     build: .
+    volumes:
+      - .:/app

--- a/docker-compose_LOCAL.yml
+++ b/docker-compose_LOCAL.yml
@@ -3,6 +3,8 @@ version: "3.6"
 services:
   python:
     build: .
+    volumes:
+      - .:/app
     network_mode: host
 
   elastic:


### PR DESCRIPTION
Implements [SYS-1642](https://uclalibrary.atlassian.net/browse/SYS-1642).

This PR adds the ability to harvest data from the legacy UCLA digital library solr index, which includes data for IDEP, ARCE, and Picturing UCLA.  There's also "legacy" data which appears to be in the newer digital library (Ursus / Samvera).  At present, nothing is filtered out; we'll need to decide how to do that later.

It took about 14 hours to copy all data from this Solr index to our production Elasticsearch instance.  For a much quicker small sample:
```
# Run the full stack locally
docker-compose -f docker-compose_LOCAL.yml up -d
# Start a python shell
docker-compose -f docker-compose_LOCAL.yml run python bash
# Harvest the first 250 records from the remote Solr index into local Elasticsearch
python centralsearch.py copy --source-url https://dl.library.ucla.edu/solr \
--elastic-url http://localhost:9200/ \
--destination-index-name systems-index-dl-legacy-test \
--profile config.dl_legacy \
--max-records 250

# In local Kibana http://localhost:5601/app/dev_tools#/console
GET /systems-index-dl-legacy-test/_search?pretty=true

# Only a small fraction of the 5200+ distinct fields from this Solr index are kept:
# Dublin Core (dc.*) and the following:
        "PID",
        "fgs_label_s",
        "mods_titleInfo_title_s",
        "mods_title_ms",
        "mods_xml",
```

Also new in this PR:
* Added a `get_solr_fields` command to `centralsearch.py`, to show all of a Solr index's unique field names and their counts across all records in the index.  Useful for surveying field names and deciding what to explore / keep.
* Mounted local code "live" into the running python container, for real-time editing without rebuilding.
* Minor code cleanup


[SYS-1642]: https://uclalibrary.atlassian.net/browse/SYS-1642?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ