### PR TITLE
SYS-1646: harvest Sheet Music data

### DIFF
--- a/centralsearch.py
+++ b/centralsearch.py
@@ -87,7 +87,7 @@ def copy(
                         max_delay=60 * 5,  # 5 min
                     )
                 except Exception as e:
-                    print(e)
+                    print(repr(e))
                 progress.update(task, total=n_hits, completed=start + index)
 
             start += chunk_size

--- a/config/sheet_music.py
+++ b/config/sheet_music.py
@@ -1,0 +1,31 @@
+SOURCE_QUERY = "*:*"
+
+
+def get_id(record: dict) -> str:
+    return record.get("id")
+
+
+def map_record(record: dict) -> dict:
+
+    # only take a selection of fields for now
+    fields_to_keep = [
+        "id",
+        "titles",
+        "publishers",
+        "subjects",
+        "names",
+    ]
+    output_record = {}
+    for fld in fields_to_keep:
+        if fld in record:
+            output_record[fld] = record[fld]
+
+    # URL for MODS record isn't in original metadata, but we can construct it
+    output_record["mods_url"] = (
+        "https://static.library.ucla.edu/sheetmusic/mods/"
+        + f"{record['collectionKey']}/{record['id']}.xml"
+    )
+    # add new field for source
+    output_record["source"] = "Sheet Music"
+
+    return output_record

--- a/config/sheet_music.py
+++ b/config/sheet_music.py
@@ -8,28 +8,20 @@ def get_id(record: dict) -> str:
 def map_record(record: dict) -> dict:
 
     # only take a selection of fields for now
-    # use the "keyword" version of fields since these are deduped
-    fields_to_keep = [
-        "id",
-        "title_keyword",
-        "publisher_keyword",
-        "subjectTopic_keyword",
-        "nameNamePart_keyword",
-        "url_keyword",
-    ]
-    keep_record = {}
-    for fld in fields_to_keep:
-        if fld in record:
-            keep_record[fld] = record[fld]
+    # use the "keyword" version of fields since these are deduped, but rename them
+    fields_to_keep = {
+        "id": "id",
+        "title_keyword": "titles",
+        "publisher_keyword": "publishers",
+        "subjectTopic_keyword": "subjects",
+        "nameNamePart_keyword": "names",
+        "url_keyword": "url",
+    }
 
-    # rename fields for consistency
     output_record = {}
-    output_record["id"] = keep_record["id"]
-    output_record["title"] = keep_record["title_keyword"]
-    output_record["publisher"] = keep_record["publisher_keyword"]
-    output_record["subject"] = keep_record["subjectTopic_keyword"]
-    output_record["name"] = keep_record["nameNamePart_keyword"]
-    output_record["url"] = keep_record["url_keyword"]
+    for fld in fields_to_keep.keys():
+        if fld in record:
+            output_record[fields_to_keep[fld]] = record[fld]
 
     # URL for MODS record isn't in original metadata, but we can construct it
     output_record["mods_url"] = (

--- a/config/sheet_music.py
+++ b/config/sheet_music.py
@@ -17,10 +17,19 @@ def map_record(record: dict) -> dict:
         "nameNamePart_keyword",
         "url_keyword",
     ]
-    output_record = {}
+    keep_record = {}
     for fld in fields_to_keep:
         if fld in record:
-            output_record[fld] = record[fld]
+            keep_record[fld] = record[fld]
+
+    # rename fields for consistency
+    output_record = {}
+    output_record["id"] = keep_record["id"]
+    output_record["title"] = keep_record["title_keyword"]
+    output_record["publisher"] = keep_record["publisher_keyword"]
+    output_record["subject"] = keep_record["subjectTopic_keyword"]
+    output_record["name"] = keep_record["nameNamePart_keyword"]
+    output_record["url"] = keep_record["url_keyword"]
 
     # URL for MODS record isn't in original metadata, but we can construct it
     output_record["mods_url"] = (

--- a/config/sheet_music.py
+++ b/config/sheet_music.py
@@ -8,12 +8,13 @@ def get_id(record: dict) -> str:
 def map_record(record: dict) -> dict:
 
     # only take a selection of fields for now
+    # use the "keyword" version of fields since these are deduped
     fields_to_keep = [
         "id",
-        "titles",
-        "publishers",
-        "subjects",
-        "names",
+        "title_keyword",
+        "publisher_keyword",
+        "subjectTopic_keyword",
+        "nameNamePart_keyword",
         "url_keyword",
     ]
     output_record = {}

--- a/config/sheet_music.py
+++ b/config/sheet_music.py
@@ -14,6 +14,7 @@ def map_record(record: dict) -> dict:
         "publishers",
         "subjects",
         "names",
+        "url_keyword",
     ]
     output_record = {}
     for fld in fields_to_keep:
@@ -23,7 +24,7 @@ def map_record(record: dict) -> dict:
     # URL for MODS record isn't in original metadata, but we can construct it
     output_record["mods_url"] = (
         "https://static.library.ucla.edu/sheetmusic/mods/"
-        + f"{record['collectionKey']}/{record['id']}.xml"
+        + f"{record['collectionKey'][0]}/{record['id']}"
     )
     # add new field for source
     output_record["source"] = "Sheet Music"


### PR DESCRIPTION
Implements [SYS-1646](https://uclalibrary.atlassian.net/browse/SYS-1646)

Adds a new module, `sheet_music.py`, to allow harvesting data from the Sheet Music Solr index. I have not tried running this against the full index. To pull a limited set for testing: 

```
python centralsearch.py copy \
    --source-url https://p-u-sheetmusicsolr01.library.ucla.edu/solr/sheetmusicprod \
    --elastic-url http://localhost:9200/ \
    --destination-index-name sheetmusic-test \
    --profile config.sheet_music \
    --max-records 250
```
As with other indexes, only a limited set of fields are retained in Elasticsearch. I chose the ones that looked the most searchable (plus the URL for general utility): 
```
        "id",
        "titles",
        "publishers",
        "subjects",
        "names",
        "url_keyword",
```

Modeled on the `samvera.py` implementation, I also added two new fields: `source`, which is the constant value "Sheet Music", and `mods_url`, which links to the full MODS document for the record.

[SYS-1646]: https://uclalibrary.atlassian.net/browse/SYS-1646?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ