### PR TITLE
SYS-1649: Copy PRL Solr data to Elasticsearch

### DIFF
--- a/config/PRL.py
+++ b/config/PRL.py
@@ -1,0 +1,32 @@
+SOURCE_QUERY = "*:*"
+
+
+def get_id(record: dict) -> str:
+    return record.get("id")
+
+
+def map_record(record: dict) -> dict:
+
+    # only take a selection of fields for now
+    # rename fields for consistency
+    fields_to_keep = {
+        "id": "id",
+        "title_keyword": "titles",
+        "description_keyword": "descriptions",
+        "publisher_keyword": "publishers",
+        "subject_keyword": "subjects",
+        "creator_keyword": "creators",
+        "contributor_keyword": "contributors",
+        "type_keyword": "types",
+        "external_link": "url",
+    }
+
+    output_record = {}
+    for fld in fields_to_keep.keys():
+        if fld in record:
+            output_record[fields_to_keep[fld]] = record[fld]
+
+    # add new field for source
+    output_record["source"] = "PRL"
+
+    return output_record

--- a/config/PRL.py
+++ b/config/PRL.py
@@ -23,7 +23,7 @@ def map_record(record: dict) -> dict:
 
     output_record = {}
     for fld in fields_to_keep.keys():
-        if fld in record:
+        if fld in record and record[fld] != [" "]:
             output_record[fields_to_keep[fld]] = record[fld]
 
     # add new field for source


### PR DESCRIPTION
Implements [SYS-1649](https://uclalibrary.atlassian.net/browse/SYS-1649)

A new python module, `PRL.py`, to harvest PRL data. Sample usage:

```
python centralsearch.py copy \
    --source-url https://p-u-prlsolr01.library.ucla.edu/solr/prl \
    --elastic-url http://localhost:9200/ \
    --destination-index-name prl-test \
    --profile config.PRL \
    --max-records 1000
```

This harvesting takes the fields listed on the left and maps them to the names on the right:
```
        "id": "id",
        "title_keyword": "titles",
        "description_keyword": "descriptions",
        "publisher_keyword": "publishers",
        "subject_keyword": "subjects",
        "creator_keyword": "creators",
        "contributor_keyword": "contributors",
        "type_keyword": "types",
        "external_link": "url",
```

A new `"source"` field is also added, with constant value `"PRL"`.

I noticed that some records, like [this one](https://p-u-prlsolr01.library.ucla.edu/solr/prl/select?q=id:%22oai:digitalgems.nus.edu.sg:90877%22), have `contributor_keyword` fields consisting only of `" "`. I added some logic in line 26 to filter out any fields that only have this value.

Related to our discussion this morning, the PRL index includes both "creator" and "contributor" fields. Let me know if you would like these mapped to an additional generic "names" field in this PR.

[SYS-1649]: https://uclalibrary.atlassian.net/browse/SYS-1649?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ