### PR TITLE
SYS-1652: harvest Sinai Palimpsests Solr data

### DIFF
--- a/config/sinai_palimpsests.py
+++ b/config/sinai_palimpsests.py
@@ -1,0 +1,39 @@
+SOURCE_QUERY = "*:*"
+
+
+def get_id(record: dict) -> str:
+    return record.get("id")
+
+
+def map_record(record: dict) -> dict:
+
+    # only take a selection of fields for now
+    # rename fields for consistency
+    fields_to_keep = {
+        "id": "id",
+        "title_tesim": "titles",
+        "alternative_title_tesim": "alternative_titles",
+        "descriptive_title_tesim": "descriptive_titles",
+        "uniform_title_tesim": "uniform_titles",
+        "contributor_tesim": "contributors",
+        "contents_tesim": "contents",
+        "contents_note_tesim": "contents_notes",
+        "keywords_tesim": "keywords",
+    }
+
+    output_record = {}
+    for fld in fields_to_keep.keys():
+        if fld in record:
+            output_record[fields_to_keep[fld]] = record[fld]
+
+    # original index doesn't contain URLs, but we can construct them
+    if "id" in output_record:
+        # replace forward slash in ARK with URL encoded '%2F'
+        ark = output_record["id"].replace("/", "%2F")
+        output_record["url"] = (
+            f"https://sinaimanuscripts.library.ucla.edu/catalog/{ark}"
+        )
+    # add new field for source
+    output_record["source"] = "Sinai Palimpsests"
+
+    return output_record

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,3 +5,6 @@ services:
     build: .
     volumes:
       - .:/app
+    extra_hosts:
+      # For access to remote resources via ssh tunnel on host
+      - "host.docker.internal:host-gateway"


### PR DESCRIPTION
Implements [SYS-1652](https://uclalibrary.atlassian.net/browse/SYS-1652)

Adds a new module, `sinai_palimpsests.py`, to allow harvesting from the Sinai Palimpsests Solr index to Elasticsearch. As this index requires SSH tunneling to access, this PR also includes a small change to `docker-compose.yml` to add an `extra_host` value.

Example usage to harvest all 985 records (after opening SSH tunnel on port 8983 to `p-u-sinaimanuscriptssolr01.library.ucla.edu`):
```
python centralsearch.py copy \
    --source-url http://host.docker.internal:8983/solr/sinaimanu \
    --elastic-url http://localhost:9200/ \
    --destination-index-name palimpsests-test \
    --profile config.sinai_palimpsests
```
The fields on the left are harvested and renamed to the values on the right:
```
        "id": "id",
        "title_tesim": "titles",
        "alternative_title_tesim": "alternative_titles",
        "descriptive_title_tesim": "descriptive_titles",
        "uniform_title_tesim": "uniform_titles",
        "contributor_tesim": "contributors",
        "contents_tesim": "contents",
        "contents_note_tesim": "contents_notes",
        "keywords_tesim": "keywords",
```

This includes four different title-like fields, which are kept separate for now in case the distinction between them is useful.

Two new fields are also added: `"source"`, which is the constant value `"Sinai Palimpsests"`, and `"url"`, which contains the direct link to the item (constructed based on the ARK).


[SYS-1652]: https://uclalibrary.atlassian.net/browse/SYS-1652?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ