### PR TITLE
SYS-1655: Copy Frontera data

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Command-line tools for working with Solr and Elasticsearch indexes.
 
 Build (first time) / rebuild (as needed):
 
-`docker-compose build`
+`docker compose build`
 
 ## Local experimentation
 
@@ -16,7 +16,7 @@ The full local environment can be used for experimenting, with local copies of
 
 To run the full system locally:
 
-`docker-compose -f docker-compose_LOCAL.yml up -d`
+`docker compose -f docker-compose_LOCAL.yml up -d`
 
 This provides 2 Solr indexes:
 * http://localhost:8983/solr/#/sinai (742 documents)
@@ -38,7 +38,7 @@ then run commands within that environment.
 
 #### Open python console using the full local environment
 
-`docker-compose -f docker-compose_LOCAL.yml run python bash`
+`docker compose -f docker-compose_LOCAL.yml run python bash`
 
 #### List commands
 
@@ -68,6 +68,17 @@ python centralsearch.py copy \
 --max-records 150
 ```
 
+#### Copy 150 records from remote Frontera index to local Elasticsearch
+```
+python centralsearch.py copy \
+--source-url https://USER:PASSWORD@frontera.library.ucla.edu/solr-proxy \
+--source-type frontera \
+--elastic-url http://localhost:9200/ \
+--destination-index-name test-frontera \
+--profile config.frontera \
+--max-records 150
+```
+
 Ignore security warnings in the local environment.
 
 #### List fields in Solr index
@@ -91,7 +102,7 @@ Elasticsearch and Kibana provide the same data, but Kibana is friendlier to use 
 
 #### Shut down the local environment
 
-`docker-compose -f docker-compose_LOCAL.yml down`
+`docker compose -f docker-compose_LOCAL.yml down`
 
 ## Production use
 
@@ -99,4 +110,4 @@ Coming soon (TM).
 
 For production use, only the python environment is needed, since it will run against real Solr and Elasticsearch instances.
 
-`docker-compose run python bash`
+`docker compose run python bash`

--- a/centralsearch.py
+++ b/centralsearch.py
@@ -7,7 +7,7 @@ import rich.progress
 from pysolr import Solr  # type: ignore
 from elasticsearch import Elasticsearch
 from elasticsearch.helpers import streaming_bulk
-from datasources import DataverseSearch, SolrSearch
+from datasources import DataverseSearch, SolrSearch, FronteraSearch
 from pprint import pprint
 
 
@@ -21,7 +21,7 @@ def centralsearch():
     "--source-type",
     default="solr",
     help="Type of data source; defaults to solr",
-    type=click.Choice(["solr", "dataverse"], case_sensitive=False),
+    type=click.Choice(["solr", "dataverse", "frontera"], case_sensitive=False),
 )
 @click.option(
     "--elastic-url",
@@ -66,6 +66,8 @@ def copy(
         searcher = SolrSearch(source_url)
     elif source_type == "dataverse":
         searcher = DataverseSearch(source_url)
+    elif source_type == "frontera":
+        searcher = FronteraSearch(source_url)
     else:
         raise (NotImplementedError(f"Unsupported {source_type=}"))
 

--- a/config/frontera.py
+++ b/config/frontera.py
@@ -1,0 +1,31 @@
+source_query = "*:*"
+
+
+def get_id(record: dict) -> str:
+    return record.get("id")
+
+
+def map_record(record: dict) -> dict:
+    fields_to_keep = {
+        "id": "id",
+        "ss_title": "title",
+        "content": "description",
+        "ss_type": "type",
+        "ss_field_recording_artist_name_string": "recording_artist_name",
+        "ss_field_composer_string": "composer",
+    }
+
+    output_record = {}
+    for fld in fields_to_keep.keys():
+        if fld in record:
+            output_record[fields_to_keep[fld]] = record[fld]
+
+    # URL isn't in original metadata, but we can construct it
+    id = record.get("id")
+    id_number = id.split("-")[-1]
+    output_record["url"] = f"https://frontera.library.ucla.edu/node/{id_number}"
+
+    # add new field for source
+    output_record["source"] = "Frontera"
+
+    return output_record

--- a/config/frontera.py
+++ b/config/frontera.py
@@ -9,7 +9,7 @@ def map_record(record: dict) -> dict:
     fields_to_keep = {
         "id": "id",
         "ss_title": "title",
-        "content": "description",
+        "content": "content",
         "ss_type": "type",
         "ss_field_recording_artist_name_string": "recording_artist_name",
         "ss_field_composer_string": "composer",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.6"
-
 services:
   python:
     build: .

--- a/docker-compose_LOCAL.yml
+++ b/docker-compose_LOCAL.yml
@@ -1,5 +1,3 @@
-version: "3.6"
-
 services:
   python:
     build: .


### PR DESCRIPTION
Implements [SYS-1655](https://uclalibrary.atlassian.net/browse/SYS-1655)

Allows harvesting Frontera data from Solr into the central Elasticsearch index. Since the Frontera Solr interface requires the use of a `query=` parameter instead of `q=`, this implementation uses a new searcher using  `requests` instead of `pysolr`. `FronteraSearch()` is defined in `datasources.py` and is closely based on `DataverseSearch()`.

Example usage to harvest all 220336 records (takes under 10 minutes for me):

```
python centralsearch.py copy \
--source-url https://frontera:frontera@frontera.library.ucla.edu/solr-proxy \
--source-type frontera \
--elastic-url http://localhost:9200/ \
--destination-index-name test-frontera \
--profile config.frontera
```

The fields on the left are harvested and renamed to the values on the right: 

```
        "id": "id",
        "ss_title": "title",
        "content": "content",
        "ss_type": "type",
        "ss_field_recording_artist_name_string": "recording_artist_name",
        "ss_field_composer_string": "composer",
```

Two new fields are added: `"source"`, which is the constant value `"Frontera"`, and `"url"`, which contains the direct link to the item (constructed based on the item's ID).

[SYS-1655]: https://uclalibrary.atlassian.net/browse/SYS-1655?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ