### PR TITLE
SYS-1618: Add harvesting for Oral History

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ then run commands within that environment.
 #### Copy data from the local Sinai Solr index to local Elasticsearch
 ```
 python centralsearch.py copy \
---source-url http://localhost:8983/solr/sinai \
---elastic-url http://localhost:9200/ \
+--source-url http://solr:8983/solr/sinai \
+--elastic-url http://elastic:9200/ \
 --destination-index-name test-sinai \
 --profile config.samvera
 ```
@@ -62,7 +62,7 @@ python centralsearch.py copy \
 python centralsearch.py copy \
 --source-url https://dataverse.ucla.edu/api/search \
 --source-type dataverse \
---elastic-url http://localhost:9200/ \
+--elastic-url http://elastic:9200/ \
 --destination-index-name test-dataverse \
 --profile config.dataverse \
 --max-records 150
@@ -73,9 +73,21 @@ python centralsearch.py copy \
 python centralsearch.py copy \
 --source-url https://USER:PASSWORD@frontera.library.ucla.edu/solr-proxy \
 --source-type frontera \
---elastic-url http://localhost:9200/ \
+--elastic-url http://elastic:9200/ \
 --destination-index-name test-frontera \
 --profile config.frontera \
+--max-records 150
+```
+
+#### Copy 150 records from remote Oral History index to local Elasticsearch
+ ```
+ # Requires update to hosts file in container and on local machine
+python centralsearch.py copy \
+--source-url https://USER:PASSWORD@oralhistory-solr.library.ucla.edu:8982/solr/blacklight-core/ \
+--source-type solr \
+--elastic-url http://elastic:9200/ \
+--destination-index-name test-oralhistory \
+--profile config.oralhistory \
 --max-records 150
 ```
 

--- a/config/oralhistory.py
+++ b/config/oralhistory.py
@@ -1,0 +1,42 @@
+SOURCE_QUERY = "*:*"
+
+
+def get_id(record: dict) -> str:
+    return record.get("id")
+
+
+def map_record(record: dict) -> dict:
+    # Only take a selection of fields for now.
+    # Rename fields as needed for consistency with other sources.
+    fields_to_keep = {
+        "id": "id",
+        "title_display": "titles",
+        "subject_topic_facet": "subjects",
+        "author_display": "names",
+        # TODO: interviewee_display - add to names, as a list?
+    }
+
+    output_record = {}
+    for fld in fields_to_keep.keys():
+        if fld in record:
+            output_record[fields_to_keep[fld]] = record[fld]
+
+    # Every record has title_display (now in titles);
+    # for now, append subtitle_display if it exists.
+    # TODO: Should titles be a list instead? (for all sources?)
+    if "subtitle_display" in record:
+        output_record["titles"] += f" {record['subtitle_display']}"
+
+    # Clean up subjects, which often has duplicates in solr data.
+    if "subjects" in output_record and isinstance(output_record["subjects"], list):
+        output_record["subjects"] = sorted(set(output_record["subjects"]))
+
+    # URL isn't in original metadata, but we can construct it.
+    output_record["url"] = (
+        f"https://oralhistory.library.ucla.edu/catalog/{get_id(record)}"
+    )
+
+    # Add new field for source.
+    output_record["source"] = "Oral History"
+
+    return output_record

--- a/datasources.py
+++ b/datasources.py
@@ -12,7 +12,11 @@ class BaseSearch(ABC):
 
     @abstractmethod
     def search(
-        self, query: str, rows_per_batch: int = 1000, max_records: int = 999_999_999
+        self,
+        query: str,
+        rows_per_batch: int = 1000,
+        max_records: int = 999_999_999,
+        **kwargs,
     ) -> Generator[dict, Any, Any]: ...
 
 
@@ -79,7 +83,11 @@ class SolrSearch(BaseSearch):
         return self._hits
 
     def search(
-        self, query: str, rows_per_batch: int = 1000, max_records: int = 999_999_999
+        self,
+        query: str,
+        rows_per_batch: int = 1000,
+        max_records: int = 999_999_999,
+        def_type: str = "lucene",
     ) -> Generator[dict, Any, Any]:
         solr_client = Solr(self.source_url, timeout=10)
 
@@ -96,7 +104,7 @@ class SolrSearch(BaseSearch):
             results = retry_call(
                 solr_client.search,
                 fargs=[query],
-                fkwargs={"defType": "lucene", "start": start, "rows": rows_per_batch},
+                fkwargs={"defType": def_type, "start": start, "rows": rows_per_batch},
             )
             self._hits = results.hits
             start += rows_per_batch

--- a/docker-compose_LOCAL.yml
+++ b/docker-compose_LOCAL.yml
@@ -3,7 +3,9 @@ services:
     build: .
     volumes:
       - .:/app
-    network_mode: host
+    extra_hosts:
+      # For access to remote resources via ssh tunnel on host
+      - "host.docker.internal:host-gateway"
 
   elastic:
     image: elasticsearch:7.17.19


### PR DESCRIPTION
Implements [SYS-1618](https://uclalibrary.atlassian.net/browse/SYS-1618).

This PR adds support for harvesting Solr data from the Oral History public site.  That Solr index uses a non-default `defType` (`edismax` instead of `lucene`, so code was updated to support passing different values via the command line.  However, on testing... `pysolr` appears to not need the `defType` explicitly passed in, though this was inconsistent when experimenting.  But if needed, add `--def-type edismax` to the command below.

The OH Solr index requires a userid and password; ask @akohler for this.  (Eventually, this will be handled via secrets.)
It also requires access via HTTPS/TLS.  See [internal documentation](https://uclalibrary.atlassian.net/wiki/spaces/DEV/pages/446038998/SSH+Tunnels+to+Solr+via+Docker#Remote-HTTPS%2FTLS-Resource) for changes needed in both your local environment and the Docker container to test this.

1. Update your local environment
2. Start the system via `docker compose -f docker-compose_LOCAL.yml up -d`
3. Run the python container: `docker compose -f docker-compose_LOCAL.yml run python bash`
4. Update `/etc/hosts` inside the container per documentation linked above
5. Inside the container, run (changing `USER:PASSWORD` to real values):
```
python centralsearch.py copy \
--source-url https://USER:PASSWORD@oralhistory-solr.library.ucla.edu:8982/solr/blacklight-core/ \
--source-type solr \
--elastic-url http://elastic:9200/ \
--destination-index-name test-oralhistory \
--profile config.oralhistory
```
This should harvest about 4941 records (as of now).


[SYS-1618]: https://uclalibrary.atlassian.net/browse/SYS-1618?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ