### PR TITLE
SYS-2163: Improve Elasticsearch error handling

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,24 @@
+{
+	"name": "Central Search Harvester",
+	"dockerComposeFile": "../docker-compose.yml",
+	"service": "python",
+	"workspaceFolder": "/home/appuser/project",
+	"customizations": {
+			"vscode": {
+					"extensions": [
+							"ms-python.python",
+							"ms-python.black-formatter",
+							"ms-python.flake8"
+					],
+					"settings": {
+							"editor.formatOnSave": true,
+							"python.analysis.typeCheckingMode": "standard",
+							"python.editor.defaultFormatter": "ms-python.black-formatter",
+					"flake8.args": [
+									"--max-line-length=100",
+									"--extend-ignore=E203"
+							]
+					}
+			}
+	}
+}

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Build (first time) / rebuild (as needed):
 ## Local experimentation
 
 The full local environment can be used for experimenting, with local copies of
-* Python (version 3.11), with required packages
+* Python (version 3.13), with required packages
 * Solr (version 7.4), with some UCLA-specific indexes
 * Elasticsearch (version 7.17.19)
 * Kibana (version 7.17.19)

--- a/datasources.py
+++ b/datasources.py
@@ -21,7 +21,7 @@ class BaseSearch(ABC):
     ) -> Generator[dict, Any, Any]: ...
 
     @abstractmethod
-    def get_fields(self, **kwargs) -> None: ...
+    def get_fields(self, *args, **kwargs) -> None: ...
 
 
 class DataverseSearch(BaseSearch):
@@ -78,7 +78,7 @@ class DataverseSearch(BaseSearch):
             for doc in data.get("items"):
                 yield doc
 
-    def get_fields(self, **kwargs):
+    def get_fields(self, *args, **kwargs):
         rows_per_batch = 1000
         max_records = 999_999_999
         query = "*&publicationStatus:Published"
@@ -127,6 +127,7 @@ class SolrSearch(BaseSearch):
         rows_per_batch: int = 1000,
         max_records: int = 999_999_999,
         def_type: str = "lucene",
+        **kwargs,
     ) -> Generator[dict, Any, Any]:
         solr_client = Solr(self.source_url, timeout=10)
 
@@ -151,7 +152,7 @@ class SolrSearch(BaseSearch):
             for doc in results.docs:
                 yield doc
 
-    def get_fields(self, def_type: str) -> None:
+    def get_fields(self, def_type: str, *args, **kwargs) -> None:
         """List all fields in all records of a Solr index,
         along with the number of times they occur."""
         source_solr = Solr(self.source_url, timeout=10, always_commit=True)
@@ -217,7 +218,7 @@ class FronteraSearch(BaseSearch):
             for doc in docs:
                 yield doc
 
-    def get_fields(self, **kwargs):
+    def get_fields(self, *args, **kwargs):
         rows_per_batch = 1000
         max_records = 999_999_999
         query = "*:*"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ services:
   python:
     build: .
     volumes:
-      - .:/app
+      - .:/home/appuser/project
     env_file:
       # Remote Elasticsearch and data source credentials
       - .docker-compose_elastic_secret.env
@@ -10,3 +10,5 @@ services:
     extra_hosts:
       # For access to remote resources via ssh tunnel on host
       - "host.docker.internal:host-gateway"
+    # Keep the container running until stopped via docker compose.
+    command: "sleep infinity"

--- a/docker-compose_ES_ONLY.yml
+++ b/docker-compose_ES_ONLY.yml
@@ -2,7 +2,7 @@ services:
   python:
     build: .
     volumes:
-      - .:/app
+      - .:/home/appuser/project
     env_file:
       # Remote data source credentials
       - .docker-compose_source_secret.env

--- a/docker-compose_FULL.yml
+++ b/docker-compose_FULL.yml
@@ -2,7 +2,7 @@ services:
   python:
     build: .
     volumes:
-      - .:/app
+      - .:/home/appuser/project
     extra_hosts:
       # For access to remote resources via ssh tunnel on host
       - "host.docker.internal:host-gateway"


### PR DESCRIPTION
Fixes [SYS-2163](https://uclalibrary.atlassian.net/browse/SYS-2163).

This PR improves error handling for the portion of `centralsearch.py` which does Elasticsearch updates.  One record in the Ursus solr system has a bad date value in its `date_dtsort` field, which caused a `elasticsearch.helpers.errors.BulkIndexError` when `streaming_bulk` tried to update it in Elasticsearch, with this message:
```
{'index': {'_index': 'central-search-calursus', '_type': '_doc', '_id': 'https://digital.library.ucla.edu/catalog/ark:/21198/zz002hftr3', 
'status': 400, 'error': {'type': 'mapper_parsing_exception', 'reason': "failed to parse field [date_dtsort] of type [date] in document 
with id 'https://digital.library.ucla.edu/catalog/ark:/21198/zz002hftr3'. Preview of field's value: '+189104-08-01T07:00:00Z'", 
'caused_by': {'type': 'illegal_argument_exception', 'reason': 'failed to parse date field [+189104-08-01T07:00:00Z] with format 
[strict_date_optional_time||epoch_millis]', 'caused_by': {'type': 'date_time_parse_exception', 'reason': 'date_time_parse_exception: 
Failed to parse with all enclosed parsers'}}}}}
```
I improved the code which updates Elasticsearch in 2 ways:
* Set `raise_on_error` and `raise_on_exception` to `False` for `streaming_bulk`.  This helper consumes a generator, so there's no easy way to `try...catch....` and continue iterating.
* Each iteration of `streaming_bulk` returns a tuple, `ok` (a boolean) and `result` (information about the action performed on the current record).  Now instead of ignoring these, the program checks the value of `ok` and prints errors if one occurs.

No attempt is made to handle problems with specific fields / values in records.  If a record causes an error, it is now skipped and the program continues with the next record.

I also made general improvements to the code:
* Fixed type hint problems in `centralsearch.py` and `datasources.py`
* Added our standard `devcontainer` configuration
* Updated to Python 3.13 in `Dockerfile`
* Minor other config / documentation tweaks

The application has no tests; I didn't add any, as testing this code change probably would require mocking Elasticsearch and testing that bad data (from the mock's POV...) does not raise an exception.

I was able to do a full harvest of Ursus into production Elasticsearch, with output showing the bad record was skipped:
```
410000 / 428324
{'index': {'_index': 'central-search-calursus', '_type': '_doc', '_id': 'https://digital.library.ucla.edu/catalog/ark:/21198/zz002hftr3', 
'status': 400, 'error': {'type': 'mapper_parsing_exception', 'reason': "failed to parse field [date_dtsort] of type [date] in document 
with id 'https://digital.library.ucla.edu/catalog/ark:/21198/zz002hftr3'. Preview of field's value: '+189104-08-01T07:00:00Z'", 
'caused_by': {'type': 'illegal_argument_exception', 'reason': 'failed to parse date field [+189104-08-01T07:00:00Z] with format 
[strict_date_optional_time||epoch_millis]', 'caused_by': {'type': 'date_time_parse_exception', 'reason': 'date_time_parse_exception: 
Failed to parse with all enclosed parsers'}}}}}
411000 / 428324
412000 / 428324
[...snip...]
428000 / 428324
Successfully indexed 428323 out of 428324 source records.
```

[SYS-2163]: https://uclalibrary.atlassian.net/browse/SYS-2163?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ